### PR TITLE
Blynx fix navigation paths

### DIFF
--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -20,7 +20,7 @@ module.exports = class Navigation {
 
 	// generate the markup for a node and its rendered children, overwrite at will
 	item(node, children) {
-		const trailingSlash = node.slug.slice(-1) === "/" ? "" : "/";
+		const trailingSlash = node.slug && node.slug.slice(-1) !== "/" ? "/" : "";
 		return `<li><a href="${this.baseURI}${node.slug}${trailingSlash}">${node.heading}</a>${children}</li>`;
 	}
 

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -20,7 +20,8 @@ module.exports = class Navigation {
 
 	// generate the markup for a node and its rendered children, overwrite at will
 	item(node, children) {
-		return `<li><a href="${this.baseURI}${node.slug}">${node.heading}</a>${children}</li>`;
+		const trailingSlash = node.slug.slice(-1) === "/" ? "" : "/";
+		return `<li><a href="${this.baseURI}${node.slug}${trailingSlash}">${node.heading}</a>${children}</li>`;
 	}
 
 	// generate the markup for a list of nodes, overwrite at will

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -20,7 +20,7 @@ module.exports = class Navigation {
 
 	// generate the markup for a node and its rendered children, overwrite at will
 	item(node, children) {
-		const trailingSlash = node.slug && node.slug.slice(-1) !== "/" ? "/" : "";
+		let trailingSlash = node.slug && node.slug.slice(-1) !== "/" ? "/" : "";
 		return `<li><a href="${this.baseURI}${node.slug}${trailingSlash}">${node.heading}</a>${children}</li>`;
 	}
 

--- a/test/expectations/atoms/button/index.html
+++ b/test/expectations/atoms/button/index.html
@@ -8,7 +8,7 @@
 	  <link href="/style.css" rel="stylesheet">
 	</head>
 	<body>
-	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms">Atoms</a><ul><li><a href="/atoms/button">Button</a></li><li><a href="/atoms/strong">strong</a></li></ul></li></ul></nav>
+	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms/">Atoms</a><ul><li><a href="/atoms/button/">Button</a></li><li><a href="/atoms/strong/">strong</a></li></ul></li></ul></nav>
 	  <main>
 		  <h1>Button</h1>
 		  <p>My favorite button:</p>

--- a/test/expectations/atoms/index.html
+++ b/test/expectations/atoms/index.html
@@ -8,7 +8,7 @@
 	  <link href="/style.css" rel="stylesheet">
 	</head>
 	<body>
-	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms">Atoms</a><ul><li><a href="/atoms/button">Button</a></li><li><a href="/atoms/strong">strong</a></li></ul></li></ul></nav>
+	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms/">Atoms</a><ul><li><a href="/atoms/button/">Button</a></li><li><a href="/atoms/strong/">strong</a></li></ul></li></ul></nav>
 	  <main>
 		  <h1>Atoms</h1>
 		  <p>indivisible units</p>

--- a/test/expectations/atoms/strong/index.html
+++ b/test/expectations/atoms/strong/index.html
@@ -8,7 +8,7 @@
 	  <link href="/style.css" rel="stylesheet">
 	</head>
 	<body>
-	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms">Atoms</a><ul><li><a href="/atoms/button">Button</a></li><li><a href="/atoms/strong">strong</a></li></ul></li></ul></nav>
+	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms/">Atoms</a><ul><li><a href="/atoms/button/">Button</a></li><li><a href="/atoms/strong/">strong</a></li></ul></li></ul></nav>
 	  <main>
 		  <h1>strong</h1>
 		  <p>This is how we <strong>flex</strong> around here.</p>

--- a/test/expectations/index.html
+++ b/test/expectations/index.html
@@ -8,7 +8,7 @@
 	  <link href="/style.css" rel="stylesheet">
 	</head>
 	<body>
-	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms">Atoms</a><ul><li><a href="/atoms/button">Button</a></li><li><a href="/atoms/strong">strong</a></li></ul></li></ul></nav>
+	  <nav><ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms/">Atoms</a><ul><li><a href="/atoms/button/">Button</a></li><li><a href="/atoms/strong/">strong</a></li></ul></li></ul></nav>
 	  <main>
 		  <h1>My Style Guide</h1>
 		  <p>welcome to your style guide</p>

--- a/test/test_navigation.js
+++ b/test/test_navigation.js
@@ -11,6 +11,6 @@ describe("navigation", () => {
 
 		let navigation = new Navigation({ baseURI: "/" });
 		let result = navigation.generate(tree);
-		assertSame(result, '<ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms">Atoms</a><ul><li><a href="/atoms/button">Button</a></li><li><a href="/atoms/strong">strong</a></li></ul></li></ul>');
+		assertSame(result, '<ul><li><a href="/">My Style Guide</a></li><li><a href="/atoms/">Atoms</a><ul><li><a href="/atoms/button/">Button</a></li><li><a href="/atoms/strong/">strong</a></li></ul></li></ul>');
 	});
 });


### PR DESCRIPTION
Adds a trailing slash to the component paths so they are referenced properly in the iframe on simple static node http servers