### PR TITLE
Changes for Architecture Summit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 aiur version history
 ====================
 
+v0.6.0
+------
+
+Several feature implementations
+
+* added: allow to configure the directories that are being watched
+* added: allow to add your own assets build via faucet with the `snippetAssets`
+  configuration
+* bug fix: `--target` works now
+
 v0.5.1
 ------
 

--- a/example/aiur.config.js
+++ b/example/aiur.config.js
@@ -5,11 +5,13 @@ exports.language = "en";
 
 exports.snippetAssets = {
 	sass: [{
-		source: "./index.scss"
+		source: "./index.scss",
+		target: "./snippet.css"
 	}],
 
 	js: [{
-		source: "./index.js"
+		source: "./index.js",
+		target: "./snippet.js"
 	}]
 };
 

--- a/example/aiur.config.js
+++ b/example/aiur.config.js
@@ -3,13 +3,15 @@
 exports.title = "Example Styleguide";
 exports.language = "en";
 
-exports.sass = [{
-	source: "./index.scss"
-}];
+exports.snippetAssets = {
+	sass: [{
+		source: "./index.scss"
+	}],
 
-exports.js = [{
-	source: "./index.js"
-}];
+	js: [{
+		source: "./index.js"
+	}]
+};
 
 exports.vendor = {
 	styles: [{

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,4 @@
-let { abort } = require("faucet-pipeline-core/lib/util");
+let { abort, repr } = require("faucet-pipeline-core/lib/util");
 let aiur = require(".");
 let parseArgs = require("minimist");
 let path = require("path");
@@ -90,17 +90,16 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		}
 	};
 
-	// TODO: This currently only supports sass and js,
-	// because we need to know the file extension
+	// TODO: This currently only supports sass and js
 	let { sass = [], js = [] } = rawConfig.snippetAssets || {};
-	sass.forEach((conf, i) => config.sass.push({
+	sass.forEach(conf => config.sass.push({
 		source: conf.source,
-		target: `${target}/snippet/${i}.css`
+		target: resolveSnippetPath(conf.target, target)
 	}));
 
-	js.forEach((conf, i) => config.js.push({
+	js.forEach(conf => config.js.push({
 		source: conf.source,
-		target: `${target}/snippet/${i}.js`
+		target: resolveSnippetPath(conf.target, target)
 	}));
 
 	let options = {
@@ -114,3 +113,13 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 
 	return { referenceDir: process.cwd(), config, options };
 };
+
+function resolveSnippetPath(filepath, referenceDir) {
+	if(!filepath) {
+		abort("ERROR: snippetAssets must have a target");
+	}
+	if(!filepath.startsWith("./")) {
+		abort(`ERROR: targets for snippetAssets must be relative: ${repr(filepath)}`);
+	}
+	return `${referenceDir}/snippet/${filepath.substring(2)}`;
+}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -79,6 +79,7 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 
 		manifest: {
 			baseURI,
+			key: "short",
 			webRoot: target
 		},
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -96,7 +96,7 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		}
 
 		entries.forEach(entry => config[pipeline].push({
-			source: entry.source,
+			...entry,
 			target: resolveSnippetPath(entry.target, target)
 		}));
 	});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -90,17 +90,16 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		}
 	};
 
-	// TODO: This currently only supports sass and js
-	let { sass = [], js = [] } = rawConfig.snippetAssets || {};
-	sass.forEach(conf => config.sass.push({
-		source: conf.source,
-		target: resolveSnippetPath(conf.target, target)
-	}));
+	Object.entries(rawConfig.snippetAssets || {}).forEach(([pipeline, entries]) => {
+		if(!config[pipeline]) {
+			config[pipeline] = [];
+		}
 
-	js.forEach(conf => config.js.push({
-		source: conf.source,
-		target: resolveSnippetPath(conf.target, target)
-	}));
+		entries.forEach(entry => config[pipeline].push({
+			source: entry.source,
+			target: resolveSnippetPath(entry.target, target)
+		}));
+	});
 
 	let options = {
 		watch: argv.watch,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -54,7 +54,8 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 	}
 
 	let { source, target } = argv;
-	// TODO: allow users to overwrite this in a custom faucet.config.js
+	let rawConfig = require(path.resolve(process.cwd(), source));
+
 	let baseURI = "/";
 	let config = {
 		aiur: [{
@@ -63,7 +64,6 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 			baseURI
 		}],
 
-		// TODO: make this configurable
 		sass: [{
 			source: "aiur/lib/style.scss",
 			target: `${target}/style-aiur.css`
@@ -90,15 +90,15 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		}
 	};
 
-	// TODO: what about LESS? How to load "unexpected" processors dynamically?
-	let { sass, js } = require(path.resolve(process.cwd(), source));
-
-	sass && sass.forEach((conf, i) => config.sass.push({
+	// TODO: This currently only supports sass and js,
+	// because we need to know the file extension
+	let { sass = [], js = [] } = rawConfig.snippetAssets || {};
+	sass.forEach((conf, i) => config.sass.push({
 		source: conf.source,
 		target: `${target}/snippet/${i}.css`
 	}));
 
-	js && js.forEach((conf, i) => config.js.push({
+	js.forEach((conf, i) => config.js.push({
 		source: conf.source,
 		target: `${target}/snippet/${i}.js`
 	}));

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,6 +55,7 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 
 	let { source, target } = argv;
 	let rawConfig = require(path.resolve(process.cwd(), source));
+	let watchDirs = rawConfig.watchDirs || [];
 
 	let baseURI = "/";
 	let config = {
@@ -74,8 +75,7 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 			target: `${target}/script-aiur.js`
 		}],
 
-		// TODO: allow users to overwrite this in a custom faucet.config.js
-		watchDirs: [source, "./components"],
+		watchDirs: [source, ...watchDirs],
 
 		manifest: {
 			baseURI,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -95,12 +95,12 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 
 	sass && sass.forEach((conf, i) => config.sass.push({
 		source: conf.source,
-		target: `${target}/style-guide-${i}.css`
+		target: `${target}/snippet/${i}.css`
 	}));
 
 	js && js.forEach((conf, i) => config.js.push({
 		source: conf.source,
-		target: `${target}/script-guide-${i}.js`
+		target: `${target}/snippet/${i}.js`
 	}));
 
 	let options = {

--- a/lib/generate_layout.js
+++ b/lib/generate_layout.js
@@ -9,7 +9,7 @@ module.exports = async (navigation, manifest) => {
 		<title>${page.title || ""}</title>
 		<meta name="description" content="${page.description || ""}">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
-		<link href="${manifest.get("dist/style-aiur.css")}" rel="stylesheet">
+		<link href="${manifest.get("style-aiur.css")}" rel="stylesheet">
 	</head>
 	<body id="aiur">
 		<nav id="aiur-nav">
@@ -20,7 +20,7 @@ module.exports = async (navigation, manifest) => {
 		<h1>${page.heading}${StatusBadge(page.status)}</h1>
 		${content}
 		</main>
-		<script src="${manifest.get("dist/script-aiur.js")}"></script>
+		<script src="${manifest.get("script-aiur.js")}"></script>
 	</body>
 </html>`;
 };

--- a/lib/site.js
+++ b/lib/site.js
@@ -81,9 +81,10 @@ module.exports = class Site {
 
 		await Promise.all(writes);
 
-		let targetAssets = this.assetManager.manifest ? Object.values(this.assetManager.manifest.toJSON()) : [];
-		let vendorAssets = require(this.source).vendor || {};
-		let snippetWrapper = new SnippetWrapper({ targetAssets, vendorAssets });
+		let snippetWrapper = new SnippetWrapper({
+			assetManager: this.assetManager,
+			vendor: require(this.source).vendor || {}
+		});
 
 		let renderedSnippets = await pageRenderer.renderedSnippets();
 		return Promise.all(renderedSnippets.map(({ html, page, slug }) => {

--- a/lib/snippet_wrapper.js
+++ b/lib/snippet_wrapper.js
@@ -1,5 +1,26 @@
-// TODO: consider using lit-html or something like that
-let wrap = (snippet, stylesBlock, scriptsBlock) => `<!doctype html>
+module.exports = class SnippetWrapper {
+	constructor({ assetManager, vendor }) {
+		this.styles = (vendor.styles || []).slice();
+		this.scripts = (vendor.scripts || []).slice();
+
+		let manifest = assetManager.manifest.toJSON();
+		Object.values(manifest).forEach(targetAsset => {
+			if(targetAsset.includes("snippet") && targetAsset.endsWith("css")) {
+				this.styles.push({ href: targetAsset });
+			} else if(targetAsset.includes("snippet") && targetAsset.endsWith("js")) {
+				this.scripts.push({ src: targetAsset });
+			}
+		});
+	}
+
+	// TODO: consider using lit-html or something like that
+	wrap(snippet) {
+		let stylesBlock = this.styles.map(style =>
+			`<link rel="stylesheet" ${attributeList(style)}>`).join("\n");
+		let scriptsBlock = this.scripts.map(script =>
+			`<script ${attributeList(script)}></script>`).join("\n");
+
+		return `<!doctype html>
 <html>
 <head>
 ${stylesBlock}
@@ -9,49 +30,9 @@ ${snippet}
 ${scriptsBlock}
 </body>
 </html>`;
-
-function generateStylesBlock(styles) {
-	if(styles) {
-		return styles.map(style => `<link rel="stylesheet" ${Object.keys(style).map(styleAttrKey => `${styleAttrKey}="${style[styleAttrKey]}"`).join(" ")}>`).join("\n");
-	}
-	return "";
-}
-
-function generateScriptsBlock(scripts) {
-	if(scripts) {
-		return scripts.map(script => `<script type="text/javascript" ${Object.keys(script).map(scriptAttrKey => `${scriptAttrKey}="${script[scriptAttrKey]}"`).join(" ")}></script>`).join("\n");
-	}
-	return "";
-}
-
-module.exports = class SnippetRenderer {
-	constructor({ targetAssets, vendorAssets }) {
-		let assets = {
-			styles: [],
-			scripts: []
-		};
-
-		if(vendorAssets.styles) {
-			assets.styles = assets.styles.concat(vendorAssets.styles);
-		}
-
-		if(vendorAssets.scripts) {
-			assets.scripts = assets.scripts.concat(vendorAssets.scripts);
-		}
-
-		targetAssets.forEach(targetAsset => {
-			if(targetAsset.indexOf("style-guide") > -1) {
-				assets.styles.push({ href: targetAsset });
-			} else if(targetAsset.indexOf("script-guide") > -1) {
-				assets.scripts.push({ src: targetAsset });
-			}
-		});
-
-		this.stylesBlock = generateStylesBlock(assets.styles) || "";
-		this.scriptsBlock = generateScriptsBlock(assets.scripts) || "";
-	}
-
-	wrap(snippet) {
-		return wrap(snippet, this.stylesBlock, this.scriptsBlock);
 	}
 };
+
+function attributeList(attributes) {
+	return Object.entries(attributes).map(([key, value]) => `${key}="${value}"`).join(" ");
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aiur",
-	"version": "0.5.2",
+	"version": "0.6.0",
 	"description": "styleguide generator",
 	"main": "lib/index.js",
 	"bin": {
@@ -21,25 +21,25 @@
 		"commonmark": "^0.29.0",
 		"complate-stream": "^0.16.9",
 		"donny": "^0.1.0",
-		"faucet-pipeline-core": "^1.3.1",
-		"faucet-pipeline-js": "^2.0.8",
-		"faucet-pipeline-jsx": "^2.0.8",
-		"faucet-pipeline-sass": "^1.3.0",
-		"faucet-pipeline-static": "^1.1.0",
-		"handlebars": "^4.4.3",
+		"faucet-pipeline-core": "^1.4.0",
+		"faucet-pipeline-js": "^2.1.1",
+		"faucet-pipeline-jsx": "^2.1.1",
+		"faucet-pipeline-sass": "^1.4.0",
+		"faucet-pipeline-static": "^1.2.0",
+		"handlebars": "^4.7.3",
 		"live-server": "^1.2.1",
 		"metacolon": "^1.0.0",
-		"minimist": "^1.2.0",
-		"mkdirp": "^0.5.1",
+		"minimist": "^1.2.5",
+		"mkdirp": "^1.0.3",
 		"parse5": "^5.1.0",
 		"prismjs": "^1.17.1",
 		"require-from-string": "^2.0.2",
-		"thymeleaf": "^0.18.0"
+		"thymeleaf": "^0.18.1"
 	},
 	"devDependencies": {
 		"eslint-config-fnd": "^1.8.0",
-		"mocha": "^7.0.1",
-		"release-util-fnd": "^1.1.1",
-		"rimraf": "^3.0.0"
+		"mocha": "^7.1.1",
+		"release-util-fnd": "^2.0.0",
+		"rimraf": "^3.0.2"
 	}
 }

--- a/test/expectations/atoms/button/0.html
+++ b/test/expectations/atoms/button/0.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
 <head>
-<link rel="stylesheet" href="style-guide-0.css">
-<link rel="stylesheet" href="style-guide-1.css">
+<link rel="stylesheet" href="snippet-0.css">
+<link rel="stylesheet" href="snippet-1.css">
 </head>
 <body>
 <button>Hello</button>
 
-<script type="text/javascript" src="script-guide-1.css"></script>
+<script src="snippet-1.js"></script>
 </body>
 </html>

--- a/test/expectations/atoms/strong/0.html
+++ b/test/expectations/atoms/strong/0.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
 <head>
-<link rel="stylesheet" href="style-guide-0.css">
-<link rel="stylesheet" href="style-guide-1.css">
+<link rel="stylesheet" href="snippet-0.css">
+<link rel="stylesheet" href="snippet-1.css">
 </head>
 <body>
 very <strong>strong</strong>
 
-<script type="text/javascript" src="script-guide-1.css"></script>
+<script src="snippet-1.js"></script>
 </body>
 </html>

--- a/test/util.js
+++ b/test/util.js
@@ -6,14 +6,14 @@ let EXPECTATIONS = path.resolve(__dirname, "expectations");
 
 class MockManifest {
 	get(path) {
-		return path.replace("dist", "");
+		return `/${path}`;
 	}
 
 	toJSON() {
 		return {
-			"dist/snippet-0.css": "snippet-0.css",
-			"dist/snippet-1.css": "snippet-1.css",
-			"dist/snippet-1.js": "snippet-1.js"
+			"snippet-0.css": "snippet-0.css",
+			"snippet-1.css": "snippet-1.css",
+			"snippet-1.js": "snippet-1.js"
 		};
 	}
 }

--- a/test/util.js
+++ b/test/util.js
@@ -11,9 +11,9 @@ class MockManifest {
 
 	toJSON() {
 		return {
-			"dist/style-guide-0.css": "style-guide-0.css",
-			"dist/style-guide-1.css": "style-guide-1.css",
-			"dist/script-guide-1.css": "script-guide-1.css"
+			"dist/snippet-0.css": "snippet-0.css",
+			"dist/snippet-1.css": "snippet-1.css",
+			"dist/snippet-1.js": "snippet-1.js"
 		};
 	}
 }


### PR DESCRIPTION
This PR contains changes @joyheron and me needed for the Architecture Summit.

* [ ] Bump version to 0.6.0
* [ ] Write the changelog
* [ ] Update dependencies

## Watch Mode

Watch Mode worked, but we just added some arbitrary `watchDirs`. This is now configurable via `watchDirs` in `aiur.config.js`

## Snippet Assets

Instead of adding `sass` and `js` to the config, you can now add a `snippetAssets` to your config. That config supports arbitrary faucet pipelines. It works like this:

```js
  snippetAssets: {
    sass: [
      {
        source: "./app/assets/stylesheets/application.scss",
        target: "./application.css"
      },
      {
        source: "./app/assets/stylesheets/styleguide.scss",
        target: "./styleguide.css"
      }
    ]
  },
```

You need to provide a target now. That target needs to be relative (otherwise, an error is thrown), because we resolve it to a special directory for snippet assets. You can configure anything the pipeline allows you to configure (transpiling JavaScript, compressing images etc.). CSS and JS files that are added here are automatically added to each snippet.

You can also use things like images. We use the `short` version of assets in the manifest.

## target

aiur supports `--target`. Previously, this didn't work though: If you chose anything but `dist`, it would not find the CSS and JS. Now it works.