### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,26 +19,26 @@
 	},
 	"dependencies": {
 		"commonmark": "^0.30.0",
-		"complate-stream": "^0.16.9",
+		"complate-stream": "^0.16.10",
 		"donny": "^0.2.0",
 		"faucet-pipeline-core": "^1.6.1",
 		"faucet-pipeline-esnext": "^2.1.7",
 		"faucet-pipeline-jsx": "^2.1.7",
-		"faucet-pipeline-sass": "^1.6.0",
+		"faucet-pipeline-sass": "^1.7.0",
 		"faucet-pipeline-static": "^1.2.0",
-		"five-server": "^0.0.26",
+		"five-server": "^0.1.2",
 		"handlebars": "^4.7.7",
-		"metacolon": "^1.1.0",
+		"metacolon": "^1.1.1",
 		"minimist": "^1.2.5",
 		"mkdirp": "^1.0.4",
 		"parse5": "^6.0.1",
-		"prismjs": "^1.23.0",
+		"prismjs": "^1.26.0",
 		"require-from-string": "^2.0.2",
 		"thymeleaf": "^0.20.5"
 	},
 	"devDependencies": {
 		"eslint-config-fnd": "^1.12.0",
-		"mocha": "^9.0.1",
+		"mocha": "^9.1.3",
 		"release-util-fnd": "^2.0.1",
 		"rimraf": "^3.0.2"
 	}


### PR DESCRIPTION
Certain dependencies have moderate vulnerabilities. This updates the
dependencies so that (a few) of these dependencies are resolved and no
longer appear in `npm audit`