### PR TITLE
Add baseuri support

### DIFF
--- a/bin/aiur
+++ b/bin/aiur
@@ -12,4 +12,6 @@ let liveserve = options.liveserve;
 delete options.liveserve;
 faucet(referenceDir, config, options);
 
-server.live(liveserve, config.manifest.webRoot);
+if (liveserve) {
+    server.live(liveserve, config.manifest.webRoot);
+}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,6 +16,8 @@ Options:
     aiur configuration file (default: ./aiur.config.js)
   -t, --target
     put the generated files here (default: ./dist)
+  --baseuri
+    base uri path the files are served from (default: /) 
   --fingerprint
     add unique hash to file names
   --sourcemaps
@@ -40,7 +42,8 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		},
 		default: {
 			source: "./aiur.config.js",
-			target: "./dist"
+			target: "./dist",
+			baseuri: "/"
 		}
 	});
 
@@ -53,16 +56,15 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 				"mode to avoid littering your file system with obsolete bundles");
 	}
 
-	let { source, target } = argv;
+	let { source, target, baseuri } = argv;
 	let rawConfig = require(path.resolve(process.cwd(), source));
 	let watchDirs = rawConfig.watchDirs || [];
 
-	let baseURI = "/";
 	let config = {
 		aiur: [{
 			source,
 			target,
-			baseURI
+			baseURI: baseuri
 		}],
 
 		sass: [{
@@ -78,7 +80,7 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		watchDirs: [source, ...watchDirs],
 
 		manifest: {
-			baseURI,
+			baseURI: baseuri,
 			key: "short",
 			webRoot: target
 		},


### PR DESCRIPTION
This commit allows specifiing the `baseuri` CLI option to generate HTML with links respecting the given parameter. It also fixes a problem with the `liveserver` option especially when this option is not given :)